### PR TITLE
Fix 4 bugs from upstream traefik-forward-auth0 issue tracker

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -279,6 +279,10 @@ pub enum SigninResult {
     },
     /// An error occurred during signin
     Error { reason: String, description: String },
+    /// An authentication error from Auth0 (returns 401)
+    AuthError { reason: String, description: String },
+    /// Nonce validation failed — redirect user to login to get a fresh nonce (#142)
+    NonceFailed { origin_url: String },
 }
 
 /// Result of signout

--- a/src/endpoints/authorize.rs
+++ b/src/endpoints/authorize.rs
@@ -146,8 +146,8 @@ fn perform_authorization(
         User::Anonymous => {
             // No valid token, need to redirect for auth
             if is_api {
-                return AuthorizeResult::AccessDenied {
-                    user: User::Anonymous,
+                // Return 401 for API requests (#128) instead of redirect
+                return AuthorizeResult::Error {
                     reason: "Authentication required".to_string(),
                 };
             }

--- a/src/endpoints/signin.rs
+++ b/src/endpoints/signin.rs
@@ -77,6 +77,27 @@ pub async fn signin(
                 format!("{}: {}", reason, description),
             ))
         }
+        SigninResult::AuthError {
+            reason,
+            description,
+        } => {
+            error!("Auth0 authentication error: {} - {}", reason, description);
+            Err((
+                StatusCode::UNAUTHORIZED,
+                format!("{}: {}", reason, description),
+            ))
+        }
+        SigninResult::NonceFailed { origin_url } => {
+            warn!("Nonce validation failed, redirecting user to {} to restart login", origin_url);
+            // Redirect user back to their original URL so the /authorize
+            // middleware can start a fresh login with a new nonce
+            let response = axum::http::Response::builder()
+                .status(StatusCode::TEMPORARY_REDIRECT)
+                .header("Location", &origin_url)
+                .body(axum::body::Body::empty())
+                .unwrap();
+            Ok(response)
+        }
     }
 }
 
@@ -86,14 +107,14 @@ async fn handle_signin(
     nonce_cookie: &Option<String>,
     app: &crate::config::ApplicationConfig,
 ) -> SigninResult {
-    // Check for error from Auth0
+    // Check for error from Auth0 (#54)
     if let Some(ref error) = params.error {
         let description = params
             .error_description
             .as_deref()
             .unwrap_or("no error description");
         error!("Received error from Auth0 on sign in: {}", description);
-        return SigninResult::Error {
+        return SigninResult::AuthError {
             reason: error.clone(),
             description: description.to_string(),
         };
@@ -138,20 +159,18 @@ async fn handle_signin(
             debug!("Nonce validation successful");
         }
         Some(cookie_nonce) => {
-            error!(
-                "Nonce mismatch: received={} cookie={}",
+            warn!(
+                "Nonce mismatch: received={} cookie={}, redirecting to login (#142)",
                 received_nonce, cookie_nonce
             );
-            return SigninResult::Error {
-                reason: "Nonce mismatch".to_string(),
-                description: "AUTH_NONCE cookie didn't match the nonce in state".to_string(),
+            return SigninResult::NonceFailed {
+                origin_url: decoded_state.origin_url(),
             };
         }
         None => {
-            warn!("AUTH_NONCE cookie not found");
-            return SigninResult::Error {
-                reason: "Missing nonce".to_string(),
-                description: "AUTH_NONCE cookie not found".to_string(),
+            warn!("AUTH_NONCE cookie not found, redirecting to login (#142)");
+            return SigninResult::NonceFailed {
+                origin_url: decoded_state.origin_url(),
             };
         }
     }

--- a/src/endpoints/signin.rs
+++ b/src/endpoints/signin.rs
@@ -88,7 +88,10 @@ pub async fn signin(
             ))
         }
         SigninResult::NonceFailed { origin_url } => {
-            warn!("Nonce validation failed, redirecting user to {} to restart login", origin_url);
+            warn!(
+                "Nonce validation failed, redirecting user to {} to restart login",
+                origin_url
+            );
             // Redirect user back to their original URL so the /authorize
             // middleware can start a fresh login with a new nonce
             let response = axum::http::Response::builder()

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -106,9 +106,7 @@ pub async fn authenticate_middleware(
                     if let Token::Jwt(ref id_jwt) = id_token {
                         // Verify sub matches between access_token and id_token
                         // to prevent token substitution attacks (#124)
-                        if !id_jwt.claims.sub.is_empty()
-                            && id_jwt.claims.sub != sub
-                        {
+                        if !id_jwt.claims.sub.is_empty() && id_jwt.claims.sub != sub {
                             debug!(
                                 "Sub mismatch: access_token sub={} id_token sub={}, ignoring id_token",
                                 sub, id_jwt.claims.sub

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -104,9 +104,20 @@ pub async fn authenticate_middleware(
                     userinfo.insert("sub".to_string(), sub.clone());
 
                     if let Token::Jwt(ref id_jwt) = id_token {
-                        for claim_name in &app.claims {
-                            if let Some(value) = id_jwt.get_claim(claim_name) {
-                                userinfo.insert(claim_name.clone(), value);
+                        // Verify sub matches between access_token and id_token
+                        // to prevent token substitution attacks (#124)
+                        if !id_jwt.claims.sub.is_empty()
+                            && id_jwt.claims.sub != sub
+                        {
+                            debug!(
+                                "Sub mismatch: access_token sub={} id_token sub={}, ignoring id_token",
+                                sub, id_jwt.claims.sub
+                            );
+                        } else {
+                            for claim_name in &app.claims {
+                                if let Some(value) = id_jwt.get_claim(claim_name) {
+                                    userinfo.insert(claim_name.clone(), value);
+                                }
                             }
                         }
                     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -294,7 +294,8 @@ async fn test_signin_with_auth0_error() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    // Auth0 auth errors should return 401 (#54)
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]
@@ -338,7 +339,7 @@ async fn test_signin_missing_state_returns_error() {
 }
 
 #[tokio::test]
-async fn test_signin_nonce_mismatch_returns_error() {
+async fn test_signin_nonce_mismatch_redirects_to_origin() {
     let mock_server = MockServer::start().await;
     let config = test_config(&mock_server.uri());
     let app = build_test_app(config);
@@ -353,7 +354,7 @@ async fn test_signin_nonce_mismatch_returns_error() {
     };
     let encoded_state = state.encode();
 
-    // Send with wrong nonce cookie
+    // Send with wrong nonce cookie — should redirect to origin URL (#142)
     let response = app
         .oneshot(
             Request::builder()
@@ -366,7 +367,16 @@ async fn test_signin_nonce_mismatch_returns_error() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    // Nonce mismatch should redirect to origin so /authorize can start fresh login
+    assert_eq!(response.status(), StatusCode::TEMPORARY_REDIRECT);
+    let location = response
+        .headers()
+        .get("location")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(location.contains("www.example.test"));
+    assert!(location.contains("/protected"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Scanned all 51 issues on [dniel/traefik-forward-auth0](https://github.com/dniel/traefik-forward-auth0/issues) and cross-referenced each bug report against our Rust port. This PR fixes the **4 real bugs** that also exist in our codebase.

## Bugs Fixed

### 🔒 #124 — Token substitution / impersonation (SECURITY)
**Original issue:** [dniel/traefik-forward-auth0#124](https://github.com/dniel/traefik-forward-auth0/issues/124) (labeled `bug`)

The `sub` claim in the access_token was never compared against the `sub` in the id_token. A user could present a valid access_token for one identity and an id_token for a **different** identity, causing the wrong user's claims to be forwarded via `x-forwardauth-*` headers.

**Fix:** In the auth middleware, when both tokens are present, we now verify the `sub` fields match. If they don't, the id_token claims are discarded (access_token identity is authoritative).

### 🔄 #142 — Nonce mismatch shows confusing 400 error
**Original issue:** [dniel/traefik-forward-auth0#142](https://github.com/dniel/traefik-forward-auth0/issues/142)

When users hit a stale nonce (expired cookie, bookmarked callback URL, browser back button), they saw `400 Bad Request` with no way to recover except clearing cookies manually. Refreshing just repeated the error.

**Fix:** Nonce mismatch and missing nonce on `/signin` now **redirect back to the original URL** (307). The `/authorize` middleware then starts a fresh login flow automatically with a new nonce.

### 🔑 #54 — Auth0 error responses return wrong status code
**Original issue:** [dniel/traefik-forward-auth0#54](https://github.com/dniel/traefik-forward-auth0/issues/54) (labeled `bug`)

When Auth0 returns `error=unauthorized&error_description=Access denied` on the `/signin` callback (e.g., Auth0 rule denied access), we returned `400 Bad Request` — a client error that doesn't convey the auth failure.

**Fix:** Auth0 authentication errors on `/signin` now return `401 Unauthorized`.

### 📡 #128 — Anonymous API requests get 403 instead of 401
**Original issue:** [dniel/traefik-forward-auth0#128](https://github.com/dniel/traefik-forward-auth0/issues/128)

When an unauthenticated client sent `Accept: application/json` or `X-Requested-With: XMLHttpRequest`, they received `403 Forbidden` instead of `401 Unauthorized`. This is semantically wrong — 403 means "authenticated but not authorized", 401 means "not authenticated".

**Fix:** Anonymous API requests now get `401 Unauthorized`.

## Bugs Already Solved in Our Port

| Original Issue | Description | Why It's Solved |
|---|---|---|
| #154 / #323 | NPE on missing headers/cookies | Rust `Option` types prevent null pointer issues |
| #136 | Headers with `_` not forwarded by Traefik | We already `replace('_', "-")` in header names |
| #141 | ClassCastException for anonymous users | Rust enum pattern matching prevents this |
| #362 / #48 | Redirect loops / URL stuck on `/oauth2/signin?code=` | State parameter stores and redirects to original URL |
| #15 / #331 | Memory usage / aarch64 support | Rust binary: ~5MB RSS, multi-arch Docker image |

## Tests

All 24 tests pass (11 unit + 13 integration). Two tests updated to assert the new correct behavior.

## Files Changed

- `src/middleware.rs` — Sub comparison between access_token and id_token
- `src/endpoints/signin.rs` — Nonce redirect + Auth0 error status code
- `src/endpoints/authorize.rs` — 401 for anonymous API requests
- `src/domain.rs` — New `SigninResult` variants
- `tests/integration_tests.rs` — Updated assertions