### PR TITLE
chore(deps): add github-actions ecosystem to dependabot

### DIFF
--- a/.agents/skills/forwardauth-rs/SKILL.md
+++ b/.agents/skills/forwardauth-rs/SKILL.md
@@ -218,6 +218,8 @@ cargo test                    # run all tests
 - `docker.yml` — builds and pushes multi-arch Docker image (`linux/amd64`, `linux/arm64`) to GHCR
 - `release.yml` — triggered by version tags; creates GitHub Release
 
+> **IMPORTANT — Protected Branch Policy:** `main` is a protected branch. All agent-driven changes MUST be committed to a new branch and submitted as a pull request. Direct pushes to `main` are not permitted. This applies to every agent task without exception — opening a PR is mandatory.
+
 **Docker image:** requires Rust ≥ 1.88 (time crate constraint). Base image: `rust:1-slim` for build, `debian:bookworm-slim` for runtime.
 
 ---

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,22 @@ updates:
     allow:
       - dependency-type: "all"
     ignore: [] # Remove this if you want to ignore specific dependencies
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "radicand"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      prefix-scope: "deps"
+      include: "scope"
+    rebase-strategy: "auto"


### PR DESCRIPTION
## Summary

Adds GitHub Actions as a second ecosystem to Dependabot so action version pins are kept up to date automatically alongside Cargo dependencies.

**Changes:**
- `.github/dependabot.yml` — adds a `github-actions` update block with the same schedule (weekly on Mondays at 04:00), reviewer, labels, and commit-message conventions as the existing `cargo` block
- `.agents/skills/forwardauth-rs/SKILL.md` — documents that `main` is a protected branch and all agent-driven work must be submitted via pull request

## Dependabot config diff

```yaml
# NEW block added
- package-ecosystem: "github-actions"
  directory: "/"
  schedule:
    interval: "weekly"
    day: "monday"
    time: "04:00"
  open-pull-requests-limit: 5
  reviewers:
    - "radicand"
  labels:
    - "dependencies"
    - "github-actions"
  commit-message:
    prefix: "chore"
    prefix-scope: "deps"
    include: "scope"
  rebase-strategy: "auto"
```