### PR TITLE
add: release-please workflow for automated versioning and releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,21 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run release-please
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: rust
+          package-name: forwardauth-rs


### PR DESCRIPTION
This PR adds the release-please GitHub Action workflow to automate versioning and release management for the forwardauth-rs project.

## Features
- Automatically creates pull requests for new releases based on conventional commits
- Updates `Cargo.toml` and `Cargo.lock` with new versions
- Generates GitHub releases with changelog
- Runs on pushes to `main` branch

## What is release-please?
release-please is a tool that automates versioning and changelog management. It:
- Monitors commits following the Conventional Commits specification
- Automatically bumps versions using semantic versioning
- Creates release PRs that can be reviewed before merging
- Generates changelogs based on commit messages
- Creates GitHub releases automatically when the release PR is merged

## Configuration
The workflow uses:
- `release-type: rust` - Optimized for Rust projects (updates Cargo.toml/Cargo.lock)
- `package-name: forwardauth-rs` - Package identifier
- Triggered on `push` to `main` branch