### PR TITLE
fix: add release-please manifest file for version tracking

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "forwardauth-rs": "2.0.0"
+}


### PR DESCRIPTION
## Problem
The release-please GitHub Action workflow failed with validation errors after being merged because the required `.release-please-manifest.json` file was missing.

## Root Cause
release-please requires a manifest file in the repository root to track the current version and generate proper release PRs. Without it:
- The action cannot determine what the next version should be
- It fails validation with "1 error and 2 warnings"

## Solution
Added `.release-please-manifest.json` which:
- Maps package name (`forwardauth-rs`) to current version (`2.0.0`)
- Matches the version in `Cargo.toml`
- Allows release-please to properly track and increment versions on future commits

## Next Steps
With this fix in place, the release-please workflow will:
1. Monitor commits following Conventional Commits spec
2. Create release PRs with updated `Cargo.toml` versions
3. Generate GitHub releases and changelogs automatically on merge