### PR TITLE
fix: release-please workflow permissions, invalid input, and Node 24 warning

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,10 +12,11 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Run release-please
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
           release-type: rust
-          package-name: forwardauth-rs


### PR DESCRIPTION
## Problem

The release-please workflow failed with three issues after being merged:

### 1. Error: Cannot create pull requests with `GITHUB_TOKEN`
```
release-please failed: GitHub Actions is not permitted to create or approve pull requests.
```
The `GITHUB_TOKEN` is blocked from creating PRs by a repository-level setting. Switched to `secrets.GH_PAT` which has the required permissions.

### 2. Warning: Invalid `package-name` input
```
Unexpected input(s) 'package-name', valid inputs are ['token', 'release-type', 'path', ...]
```
`package-name` is not a valid input for `googleapis/release-please-action@v4`. Removed it.

### 3. Warning: Node.js 20 deprecation
```
Node.js 20 actions are deprecated... Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
```
Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var to opt in now and suppress the warning.

## Changes
- `.github/workflows/release-please.yml`: Replace `GITHUB_TOKEN` → `GH_PAT`, remove `package-name`, add Node 24 opt-in