### PR TITLE
feat: add jwks-url config override for non-Auth0 OIDC providers

### DIFF
--- a/src/auth0.rs
+++ b/src/auth0.rs
@@ -429,7 +429,11 @@ impl Auth0Client {
     /// traffic, only one HTTP request is issued; all other callers await that
     /// single in-flight request instead of each firing their own.
     async fn get_jwks_keys(&self) -> Result<Vec<JwksKey>, anyhow::Error> {
-        let jwks_uri = format!("{}.well-known/jwks.json", self.config.domain);
+        let jwks_uri = self
+            .config
+            .jwks_url
+            .clone()
+            .unwrap_or_else(|| format!("{}.well-known/jwks.json", self.config.domain));
         let http = self.http.clone();
         let uri_for_log = jwks_uri.clone();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,11 @@ use url::Url;
 pub struct AppConfig {
     /// Auth0 domain URL (e.g., https://xxx.auth0.com/)
     pub domain: String,
+    /// Optional JWKS URI override. When set, used instead of the default
+    /// `{domain}/.well-known/jwks.json` construction. Useful for providers
+    /// like authentik where the JWKS URI differs from the Auth0 convention.
+    #[serde(default)]
+    pub jwks_url: Option<String>,
     /// Auth0 token endpoint (e.g., https://xxx.auth0.com/oauth/token)
     pub token_endpoint: String,
     /// Auth0 authorize URL (e.g., https://xxx.auth0.com/authorize)


### PR DESCRIPTION
## Problem

`get_jwks_keys` hardcodes the JWKS URL as `{domain}/.well-known/jwks.json` (Auth0 convention). Authentik exposes JWKS at `{domain}jwks/`, causing a 404 HTML response that fails JSON deserialization with `error decoding response body`.

## Solution

Add an optional `jwks-url` top-level config field. When set, it overrides the constructed URL. When absent, behaviour is unchanged (falls back to `{domain}.well-known/jwks.json`).

**config.yaml example for authentik:**
```yaml
domain: https://auth.example.com/application/o/myapp/
jwks-url: https://auth.example.com/application/o/myapp/jwks/
token-endpoint: https://auth.example.com/application/o/token/
# ...
```