### PR TITLE
fix: use form-encoded body for OAuth2 token exchange

### DIFF
--- a/src/auth0.rs
+++ b/src/auth0.rs
@@ -61,7 +61,8 @@ pub struct CachedToken {
 /// Response from Auth0 token endpoint
 #[derive(Debug, Deserialize)]
 pub struct TokenResponse {
-    pub access_token: String,
+    #[serde(default)]
+    pub access_token: Option<String>,
     #[serde(default)]
     pub id_token: Option<String>,
     #[serde(default)]
@@ -112,20 +113,19 @@ impl Auth0Client {
     ) -> Result<TokenResponse, anyhow::Error> {
         debug!("Performing authorization code exchange");
 
-        let body = serde_json::json!({
-            "grant_type": "authorization_code",
-            "client_id": client_id,
-            "client_secret": client_secret,
-            "redirect_uri": redirect_uri,
-            "code": code,
-            "scope": "openid id_token"
-        });
+        let params = [
+            ("grant_type", "authorization_code"),
+            ("client_id", client_id),
+            ("client_secret", client_secret),
+            ("redirect_uri", redirect_uri),
+            ("code", code),
+            ("scope", "openid id_token"),
+        ];
 
         let response = self
             .http
             .post(&self.config.token_endpoint)
-            .header("content-type", "application/json")
-            .json(&body)
+            .form(&params)
             .send()
             .await?;
 
@@ -184,19 +184,14 @@ impl Auth0Client {
             .try_get_with(cache_key, async move {
                 debug!("Requesting client credentials token from Auth0");
 
-                let body = serde_json::json!({
-                    "grant_type": "client_credentials",
-                    "client_id": client_id_owned,
-                    "client_secret": client_secret_owned,
-                    "audience": audience_owned
-                });
+                let params = [
+                    ("grant_type", "client_credentials".to_string()),
+                    ("client_id", client_id_owned),
+                    ("client_secret", client_secret_owned),
+                    ("audience", audience_owned),
+                ];
 
-                let response = http
-                    .post(&token_endpoint)
-                    .header("content-type", "application/json")
-                    .json(&body)
-                    .send()
-                    .await?;
+                let response = http.post(&token_endpoint).form(&params).send().await?;
 
                 let json: serde_json::Value = response.json().await?;
 

--- a/src/endpoints/signin.rs
+++ b/src/endpoints/signin.rs
@@ -185,11 +185,12 @@ async fn handle_signin(
         .await
     {
         Ok(token_resp) => {
+            let access_token = token_resp.access_token.unwrap_or_default();
             let id_token = token_resp.id_token.unwrap_or_default();
             let expires_in = token_resp.expires_in.unwrap_or(86400);
 
             SigninResult::Complete {
-                access_token: token_resp.access_token,
+                access_token,
                 id_token,
                 expires_in,
                 redirect_to: decoded_state.origin_url(),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -22,9 +22,10 @@ use rsa::traits::PublicKeyParts;
 use rsa::RsaPrivateKey;
 use serde_json::json;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tower::ServiceExt;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{body_string_contains, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 const TEST_JWT_KID: &str = "integration-test-key-1";
@@ -496,6 +497,15 @@ async fn test_signin_successful_exchange() {
     // Mock the token endpoint
     Mock::given(method("POST"))
         .and(path("/oauth/token"))
+        .and(header("content-type", "application/x-www-form-urlencoded"))
+        .and(body_string_contains("grant_type=authorization_code"))
+        .and(body_string_contains("client_id=test-client-id"))
+        .and(body_string_contains("client_secret=test-client-secret"))
+        .and(body_string_contains(
+            "redirect_uri=https%3A%2F%2Fwww.example.test%2Foauth2%2Fsignin",
+        ))
+        .and(body_string_contains("code=valid-code"))
+        .and(body_string_contains("scope=openid+id_token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "access_token": "test-access-token",
             "id_token": "test-id-token",
@@ -553,6 +563,40 @@ async fn test_signin_successful_exchange() {
     assert!(cookies.iter().any(|c| c.contains("JWT_TOKEN=")));
     // Should clear nonce cookie
     assert!(cookies.iter().any(|c| c.contains("AUTH_NONCE=deleted")));
+}
+
+#[tokio::test]
+async fn test_client_credentials_exchange_uses_form_encoded_body() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .and(header("content-type", "application/x-www-form-urlencoded"))
+        .and(body_string_contains("grant_type=client_credentials"))
+        .and(body_string_contains("client_id=test-client-id"))
+        .and(body_string_contains("client_secret=test-client-secret"))
+        .and(body_string_contains(
+            "audience=https%3A%2F%2Fapi.example.test",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "test-client-credentials-token",
+            "token_type": "Bearer",
+            "expires_in": 3600
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = forwardauth_rs::auth0::Auth0Client::new(Arc::new(test_config(&mock_server.uri())));
+    let access_token = client
+        .client_credentials_exchange(
+            "test-client-id",
+            "test-client-secret",
+            "https://api.example.test",
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(access_token, "test-client-credentials-token");
 }
 
 // ==================== /signout endpoint ====================


### PR DESCRIPTION
## Problem

Token exchange with Authentik (and potentially other strict OIDC providers) fails with "error decoding response body" because:

1. **JSON body on token endpoint**: The code sends `application/json` to the `/token` endpoint, but [RFC 6749 §4.1.3](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3) requires `application/x-www-form-urlencoded`. Authentik cannot parse client credentials from a JSON body and returns `invalid_client`.

2. **Required `access_token` field**: The `TokenResponse` struct has `access_token: String` (required), so when the token endpoint returns an error response (which has `error`/`error_description` but no `access_token`), serde deserialization fails entirely — producing the unhelpful "error decoding response body" message.

## Fix

- Switch both `authorization_code_exchange` and `client_credentials_exchange` from `.json(&body)` to `.form(&params)` 
- Make `access_token` optional (`Option<String>`) in `TokenResponse` so error responses deserialize properly

## Testing

- All 26 existing tests pass
- Verified against Authentik token endpoint: form-encoded requests get proper `invalid_grant` responses (vs `invalid_client` with JSON)