### PR TITLE
feat: add multi-arch Docker builds and semver tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Read version from Cargo.toml
+        id: cargo_version
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -34,6 +40,12 @@ jobs:
           tags: |
             type=sha
             type=raw,value=edge
+            type=raw,value=${{ steps.cargo_version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ steps.cargo_version.outputs.version }}
+            type=semver,pattern={{major}},value=v${{ steps.cargo_version.outputs.version }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -42,6 +54,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Adds ARM64 support and semver Docker tags.

Changes:
- Add QEMU for cross-platform emulation
- Build for linux/amd64 and linux/arm64  
- Add semver tags (X.Y.Z, X.Y, X) extracted from Cargo.toml
- Keep existing sha and edge tags

This is needed because the k3s cluster runs on ARM64 (Raspberry Pi) nodes, and the current amd64-only image fails with 'no match for platform in manifest'.