### PR TITLE
fix: simplify release pipeline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   docker:
-    name: Build & Push Docker Image
+    name: Build & Push Docker Image (edge)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,12 +26,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Read version from Cargo.toml
-        id: cargo_version
-        run: |
-          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -40,12 +34,6 @@ jobs:
           tags: |
             type=sha
             type=raw,value=edge
-            type=raw,value=${{ steps.cargo_version.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=v${{ steps.cargo_version.outputs.version }}
-            type=semver,pattern={{major}},value=v${{ steps.cargo_version.outputs.version }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -54,7 +42,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'forwardauth-rs-v*'
 
 env:
   REGISTRY: ghcr.io
@@ -92,15 +92,23 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Extract version
+        id: version
+        run: |
+          # Strip 'forwardauth-rs-v' prefix to get bare version
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#forwardauth-rs-v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},value=v${{ steps.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ steps.version.outputs.version }}
+            type=semver,pattern={{major}},value=v${{ steps.version.outputs.version }}
             type=raw,value=latest
 
       - name: Create and push manifest


### PR DESCRIPTION
## Changes

- **docker.yml**: Fast amd64-only edge builds on every commit to main (removes QEMU)
- **release.yml**: Fix tag trigger from `v*` to `forwardauth-rs-v*` to match release-please config

## Why

Regular commits were incorrectly pushing semver-tagged docker images with QEMU cross-compilation, which is slow. Now:
- Regular commits → fast `sha` + `edge` tags only (amd64)
- Release-please tags → multi-arch semver releases (`2.3.1`, `2.3`, `2`, `latest`) on native runners