### PR TITLE
feat(chart): add existingSecret support for config volume

### DIFF
--- a/helm/forwardauth/templates/deployment.yaml
+++ b/helm/forwardauth/templates/deployment.yaml
@@ -55,8 +55,13 @@ spec:
               readOnly: true
       volumes:
         - name: config
+          {{- if .Values.existingSecret }}
+          secret:
+            secretName: {{ .Values.existingSecret }}
+          {{- else }}
           configMap:
             name: {{ .Values.existingConfigMap | default (include "forwardauth.fullname" .) }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/forwardauth/values.yaml
+++ b/helm/forwardauth/values.yaml
@@ -22,6 +22,7 @@ ingress:
   tls: []
 applicationYaml: {}
 existingConfigMap: ''
+existingSecret: ''
 resources:
   limits:
     memory: 64Mi


### PR DESCRIPTION
Adds `existingSecret` value to the Helm chart. When set, the deployment mounts the config volume from a Kubernetes Secret instead of a ConfigMap. This enables proper secret management for OIDC credentials via SealedSecrets or external secret operators, without exposing sensitive values in ConfigMaps.

**Changes:**
- `templates/deployment.yaml`: Conditional volume source — uses `secret` when `existingSecret` is set, otherwise falls back to `configMap` (existing behavior)
- `values.yaml`: Added `existingSecret: ''` default

**Usage:**
```yaml
# Create a K8s Secret with key "application.yaml" containing the full config
existingSecret: my-forwardauth-config
applicationYaml: {}  # ignored when existingSecret is set
```